### PR TITLE
Add email as required field in profile serializer

### DIFF
--- a/pyinv/accounts/serializers.py
+++ b/pyinv/accounts/serializers.py
@@ -4,6 +4,8 @@ from rest_framework import serializers
 
 class ProfileSerializer(serializers.ModelSerializer):
 
+    email = serializers.EmailField(required=True)
+
     class Meta:
         model = User
         fields = (


### PR DESCRIPTION
We do not want users to be able to remove their email address in case we need to contact them.

If a user wants their data to be completely removed, that action should be performed by an admin.